### PR TITLE
Setting Use to clear out ACL tokens when switching stacks

### DIFF
--- a/.changes/unreleased/Added-20240711-233913.yaml
+++ b/.changes/unreleased/Added-20240711-233913.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Set Use to clear previous ACL tokens when called to avoid conflicts
+time: 2024-07-11T23:39:13.520023-05:00
+custom:
+    Author: Shackelford-Arden

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,21 @@
+package cmd
+
+func unsetTokens(shell string) string {
+
+	output := ""
+
+	switch shell {
+	case "bash":
+		fallthrough
+	case "zsh":
+		fallthrough
+	default:
+		output = `
+unset NOMAD_TOKEN
+unset CONSUL_TOKEN
+unset VAULT_TOKEN
+`
+	}
+
+	return output
+}


### PR DESCRIPTION
Been having to run `unset NOMAD_TOKEN` far too often when switching stacks due to cached tokens being invalid.

Also had some scenarios where while caching was disabled, if any tokens were previously cached pre-disabling cache, really old tokens would get pulled in.